### PR TITLE
fix(tools): enable header file checking in clang-tidy config

### DIFF
--- a/modules/common/include/nioc/common/locked.hpp
+++ b/modules/common/include/nioc/common/locked.hpp
@@ -57,13 +57,13 @@ namespace nioc::common
 ///                     Access by r-reference:
 ///                         [](auto&& value){ doSomething(); return somethingOrNot(); }
 ///
-/// @tparam     ValueType_  Type of the underlying variable. Any const qualifiers
+/// @tparam     ValueTypeT  Type of the underlying variable. Any const qualifiers
 ///                         specifiers are discarded.
-template<typename ValueType_>
+template<typename ValueTypeT>
 class Locked
 {
 public:
-  using ValueType = typename std::remove_const<ValueType_>::type;
+  using ValueType = typename std::remove_const_t<ValueTypeT>;
 
   /// @brief  Variadic constructor that accepts and forwards any arguments to the
   ///         constructor of the underlying types.
@@ -74,7 +74,7 @@ public:
   /// @param  args    Parameter pack to be forwarded as arguments to the
   ///                 constructor of the underlying value a.k.a Locked::mLockedValue
   template<typename... Args>
-  explicit Locked(Args&&... args): mMutex{}, mLockedValue{ std::forward<Args>(args)... }
+  explicit Locked(Args&&... args): mLockedValue{ std::forward<Args>(args)... }
   {
   }
 

--- a/tools/clang-tidy-19
+++ b/tools/clang-tidy-19
@@ -12,7 +12,7 @@ ImplementationFileExtensions:
   - cc
   - cpp
   - cxx
-HeaderFilterRegex: ''
+HeaderFilterRegex: '.*'
 ExcludeHeaderFilterRegex: ''
 FormatStyle:     none
 User:            ajakhotia
@@ -403,7 +403,7 @@ CheckOptions:
   readability-identifier-naming.StaticConstantPrefix: k
   readability-identifier-naming.StructCase: CamelCase
   readability-identifier-naming.TemplateParameterCase: CamelCase
-  readability-identifier-naming.TemplateParameterSuffix: _
+  readability-identifier-naming.TemplateParameterSuffix: ''
   readability-identifier-naming.TypeAliasCase: CamelCase
   readability-identifier-naming.TypedefCase: CamelCase
   readability-identifier-naming.VariableCase: camelBack


### PR DESCRIPTION
- Set HeaderFilterRegex to '.*' to check all project headers
- Remove template parameter suffix requirement for cleaner naming